### PR TITLE
Feature: add other properties from docProps/app.xml to context

### DIFF
--- a/docx2python/docx_context.py
+++ b/docx2python/docx_context.py
@@ -276,6 +276,12 @@ def get_context(zipf: zipfile.ZipFile) -> Dict[str, Any]:
         # no document properties. This file may have come from Google Docs
         context["docProp2text"] = {}
     try:
+        for key, val in collect_docProps(zipf.read("docProps/app.xml")).items():
+            context["docProp2text"][key] = val
+    except KeyError:
+        # no document properties. This file may have come from Google Docs
+        pass
+    try:
         numId2numFmts = collect_numFmts(zipf.read("word/numbering.xml"))
         context["numId2numFmts"] = numId2numFmts
         context["numId2count"] = {


### PR DESCRIPTION
A simple extension to the set of properties in .docx files.

_Considerations:_
1. Add a new key in `context` for app.xml data
2. Add handler to check for duplicate properties in `context["docProp2text"]` before app.xml data is inserted.