### PR TITLE
Able to detected checked boxes correctly for badly formatted xml.

### DIFF
--- a/docx2python/forms.py
+++ b/docx2python/forms.py
@@ -45,6 +45,8 @@ def get_checkBox_entry(checkBox: Element) -> str:
 
     def get_wval() -> Union[str, None]:
         with suppress(AttributeError, KeyError):
+            if (len(checkBox.find(qn("w:checked")).attrib.keys()) == 0):
+                return "1"
             return checkBox.find(qn("w:checked")).attrib[qn("w:val")]
         with suppress(AttributeError, KeyError):
             return checkBox.find(qn("w:default")).attrib[qn("w:val")]


### PR DESCRIPTION
Word docx's xml (i believe this is cause the docx version is pretty old) deletes w:val when the checkbox is checked and has w:val = 0 when the checkbox isn't checked.

This causes a problems that the library defaults to 0 when w:val isn't found in w:checked. To fix this, I just checked if there is anything attributes in w:check and return a 1 if there isn't anything there. 

I can probably edit the code to check if w:val exist instead as I don't know if w:checked can have other attributes.
Thank for have this library be able to display checkboxes, it is super useful when parsing through forms that have all of their stuff in tables.