### PR TITLE
Fixed a bug with scrubbed documents.

### DIFF
--- a/docx2python/docx_output.py
+++ b/docx2python/docx_output.py
@@ -436,8 +436,10 @@ class DocxContent:
         for comment in comment_elements:
             id_ = get_attrib_by_qn(comment, "w:id")
             author = get_attrib_by_qn(comment, "w:author")
-            date = get_attrib_by_qn(comment, "w:date")
-
+            try:
+                date = get_attrib_by_qn(comment, "w:date")
+            except KeyError:
+                date = ""
             tree = new_depth_collector(comments_file, comment).tree_text
             tree_pars = ["".join(x) for x in iter_at_depth(tree, 4)]
             comment_text = "\n\n".join(tree_pars)


### PR DESCRIPTION
Fixed a `KeyError` that would only crop up if a word document has been scrubbed of personal data.

You can test this by opening a word doc with comments and then going through `File`->`Info`->`Check for Issues`->`Inspect Document`, then click `Remove All` for `Document Properties and Personal Information`